### PR TITLE
FIX: Retry later if API is not creating a new ticket

### DIFF
--- a/app/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings.rb
+++ b/app/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jobs
   class MigrateZendeskEnabledCategoriesSiteSettings < ::Jobs::Onceoff
     def execute_onceoff(_)

--- a/spec/integration/zendesk_plugin_spec.rb
+++ b/spec/integration/zendesk_plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 RSpec.describe 'Discourse Zendesk Plugin' do
   let(:admin) { Fabricate(:admin) }
@@ -15,11 +17,11 @@ RSpec.describe 'Discourse Zendesk Plugin' do
   end
 
   before do
-    default_header = {'Content-Type' => 'application/json; charset=UTF-8'}
+    default_header = { 'Content-Type' => 'application/json; charset=UTF-8' }
     stub_request(:post, zendesk_api_ticket_url).
       to_return(status: 200, body: ticket_response, headers: default_header)
     stub_request(:get, zendesk_url_default + "/users/me").
-      to_return(status: 200, body: {user: {}}.to_json, headers: default_header )
+      to_return(status: 200, body: { user: {} }.to_json, headers: default_header)
   end
 
   describe 'Plugin Settings' do

--- a/spec/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings_spec.rb
+++ b/spec/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Jobs::MigrateZendeskEnabledCategoriesSiteSettings do


### PR DESCRIPTION
Trying to update custom fields if the ticket is `nil` will throw an error.

Since we need to be more defensive when interacting with remote APIs,  we can:

  - Retry the job in the future.
  - Return nil and abort the job.

My change here proposes the first option. Does it make sense to just re-queue it indefinitely or we should limit the number of tries?
