### PR TITLE
FEATURE: zendesk two-way sync

### DIFF
--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module DiscourseZendeskPlugin
+  class SyncController < ApplicationController
+    include ::DiscourseZendeskPlugin::Helper
+    layout false
+    before_action :set_api_key_from_params
+    skip_before_action :check_xhr, :preload_json, :verify_authenticity_token, only: [:webhook]
+
+    def webhook
+      unless SiteSetting.zendesk_enabled? && SiteSetting.sync_comments_from_zendesk
+        return render json: failed_json, status: 422
+      end
+
+      ticket_id = params[:ticket_id]
+      raise Discourse::InvalidParameters.new(:ticket_id) if ticket_id.blank?
+      topic = Topic.find_by_id(params[:topic_id])
+      raise Discourse::InvalidParameters.new(:topic_id) if topic.blank?
+      return if !DiscourseZendeskPlugin::Helper.category_enabled?(topic.category_id)
+
+      user = User.find_by_email(params[:email]) || current_user
+      latest_comment = get_latest_comment(ticket_id)
+      if latest_comment.present?
+        existing_comment = PostCustomField.where(name: ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD, value: latest_comment.id).first
+
+        unless existing_comment.present?
+          post = topic.posts.create!(
+            user: user,
+            raw: latest_comment.body
+          )
+          update_post_custom_fields(post, latest_comment)
+        end
+      end
+
+      render json: {}, status: 204
+    end
+
+    private
+
+    def set_api_key_from_params
+      request.env[Auth::DefaultCurrentUserProvider::API_KEY] ||= params[:api_key]
+    end
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -14,4 +14,5 @@ en:
     zendesk_jobs_api_token: API token for Zendesk authentication
     zendesk_jobs_email: Email to use for Zendesk authentication
     zendesk_job_push_all_posts: Push all posts in a topic as Zendesk comments? If disabled only first post will be pushed to Zendesk.
+    sync_comments_from_zendesk: Autopost comments from Zendesk to Discourse. Only applies for topics in `zendesk_enabled_categories`.
     zendesk_tags: List of tags to add to each ticket

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,8 @@ plugins:
     default: ''
   zendesk_job_push_all_posts:
     default: true
+  sync_comments_from_zendesk:
+    default: false
   zendesk_tags:
     type: list
     client: false

--- a/lib/discourse_zendesk_plugin/engine.rb
+++ b/lib/discourse_zendesk_plugin/engine.rb
@@ -8,6 +8,7 @@ module DiscourseZendeskPlugin
     config.after_initialize do
       Discourse::Application.routes.append do
         post '/zendesk-plugin/issues' => 'discourse_zendesk_plugin/issues#create', constraints: StaffConstraint.new
+        put '/zendesk-plugin/sync' => 'discourse_zendesk_plugin/sync#webhook'
       end
     end
   end

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -26,6 +26,7 @@ module DiscourseZendeskPlugin
           submitter_id: zendesk_user_id,
           priority: "normal",
           tags: SiteSetting.zendesk_tags.split('|'),
+          external_id: post.topic.id,
           custom_fields: [
             imported_from: ::Discourse.current_hostname,
             external_id: post.topic.id,
@@ -53,6 +54,16 @@ module DiscourseZendeskPlugin
         ticket.save
         update_post_custom_fields(post, ticket.comments.last)
       end
+    end
+
+    def get_latest_comment(ticket_id)
+      ticket = ZendeskAPI::Ticket.new(zendesk_client, id: ticket_id)
+      last_public_comment = nil
+
+      ticket.comments.all! do |comment|
+        last_public_comment = comment if comment.public
+      end
+      last_public_comment
     end
 
     def update_topic_custom_fields(topic, ticket)

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,6 +22,7 @@ end
 
 after_initialize do
   require_dependency File.expand_path('../app/controllers/discourse_zendesk_plugin/issues_controller.rb', __FILE__)
+  require_dependency File.expand_path('../app/controllers/discourse_zendesk_plugin/sync_controller.rb', __FILE__)
   require_dependency File.expand_path('../app/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings.rb', __FILE__)
   require_dependency File.expand_path('../app/jobs/regular/zendesk_job.rb', __FILE__)
 

--- a/spec/requests/sync_controller_spec.rb
+++ b/spec/requests/sync_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe DiscourseZendeskPlugin::SyncController do
+
+  context "#webhook" do
+    let!(:topic) { Fabricate(:topic) }
+
+    before do
+      SiteSetting.zendesk_enabled = true
+      SiteSetting.sync_comments_from_zendesk = true
+    end
+
+    it 'raises an error if the plugin is disabled' do
+      SiteSetting.zendesk_enabled = false
+      put '/zendesk-plugin/sync.json'
+      expect(response.status).to eq(422)
+    end
+
+    it 'raises an error if `sync_comments_from_zendesk` is disabled' do
+      SiteSetting.sync_comments_from_zendesk = false
+      put '/zendesk-plugin/sync.json'
+      expect(response.status).to eq(422)
+    end
+
+    it 'raises an error if required parameters are missing' do
+      put "/zendesk-plugin/sync.json", params: { topic_id: topic.id }
+      expect(response.status).to eq(400)
+    end
+
+    it 'raises an error when topic is not present' do
+      put "/zendesk-plugin/sync.json", params: { topic_id: 24, ticket_id: 12 }
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns 204 when the request succeeds' do
+      put "/zendesk-plugin/sync.json", params: { topic_id: topic.id, ticket_id: 12 }
+      expect(response.status).to eq(204)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an API endpoint that will create a new post (zendesk comment) on a topic when the Zendesk webhook gets triggered.

To get this working more changes are required on Zendesk side which I'll document on meta soon.