### PR TITLE
FEATURE: Make post source more obvious

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,7 +10,7 @@ en:
   site_settings:
     zendesk_url: Your Zendesk URL. e.g. https://YOUR_SUBDOMAIN.zendesk.com/api/v2
     zendesk_enabled: Enable Zendesk plugin
-    zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets
+    zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets. The wildcard * will create tickets for all categories.
     zendesk_jobs_api_token: API token for Zendesk authentication
     zendesk_jobs_email: Email to use for Zendesk authentication
     zendesk_job_push_all_posts: Push all posts in a topic as Zendesk comments? If disabled only first post will be pushed to Zendesk.

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,7 +10,8 @@ en:
   site_settings:
     zendesk_url: Your Zendesk URL. e.g. https://YOUR_SUBDOMAIN.zendesk.com/api/v2
     zendesk_enabled: Enable Zendesk plugin
-    zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets. The wildcard * will create tickets for all categories.
+    zendesk_all_categories: Create tickets for all categories? If enabled, `zendesk_enabled_categories` are ignored.
+    zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets.
     zendesk_jobs_api_token: API token for Zendesk authentication
     zendesk_jobs_email: Email to use for Zendesk authentication
     zendesk_job_push_all_posts: Push all posts in a topic as Zendesk comments? If disabled only first post will be pushed to Zendesk.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,8 @@ plugins:
     secret: true
   zendesk_jobs_email:
     default: ''
+  zendesk_all_categories:
+    default: false
   zendesk_enabled_categories:
     type: category_list
     client: false

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -100,7 +100,7 @@ module DiscourseZendeskPlugin
       style.format_html
       html = style.to_html
 
-      "#{html} \n\n [<a href='#{post.full_url}'>source</a>]"
+      "#{html} \n\n [<a href='#{post.full_url}'>Discourse post</a>]"
     end
   end
 end

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -15,9 +15,10 @@ module DiscourseZendeskPlugin
 
       category_arr = SiteSetting.zendesk_enabled_categories.split('|')
       if category_arr.include?("*")
-        return True
+        true
       else
         category_arr.include?(category_id.to_s)
+      end
     end
 
     def create_ticket(post)

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -13,11 +13,10 @@ module DiscourseZendeskPlugin
     def self.category_enabled?(category_id)
       return false unless category_id.present?
 
-      category_arr = SiteSetting.zendesk_enabled_categories.split('|')
-      if category_arr.include?("*")
+      if SiteSetting.zendesk_all_categories?
         true
       else
-        category_arr.include?(category_id.to_s)
+        SiteSetting.zendesk_enabled_categories.split('|').include?(category_id.to_s)
       end
     end
 

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -13,7 +13,11 @@ module DiscourseZendeskPlugin
     def self.category_enabled?(category_id)
       return false unless category_id.present?
 
-      SiteSetting.zendesk_enabled_categories.split('|').include?(category_id.to_s)
+      category_arr = SiteSetting.zendesk_enabled_categories.split('|')
+      if category_arr.include?("*")
+        return True
+      else
+        category_arr.include?(category_id.to_s)
     end
 
     def create_ticket(post)


### PR DESCRIPTION
With many integrations in Zendesk, it's not very obvious to agents that Discourse posts are coming from potentially public forums.