### PR TITLE
Bump Zendesk gem version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Yana Agun Siswanto
+Copyright (c) 2021 Civilized Discourse Construction Kit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,13 +2,11 @@
 
 # name: discourse-zendesk-plugin
 # about: Zendesk for Discourse
-# authors: Yana Agun Siswanto (Inspired by shiv kumar's Zendesk-Plugin)
+# authors: Yana Agun Siswanto, Arpit Jalan
 # url: https://github.com/discourse/discourse-zendesk-plugin
 
 gem 'inflection', '1.0.0'
-gem 'mime-types-data', '3.2019.1009'
-gem 'mime-types', '3.3.1'
-gem 'zendesk_api', '1.28.0'
+gem 'zendesk_api', '1.29.0'
 
 enabled_site_setting :zendesk_enabled
 load File.expand_path('lib/discourse_zendesk_plugin/engine.rb', __dir__)


### PR DESCRIPTION
The latest Zendesk gem version (1.29.0) deprecates `mime-types` gem in favour of `mini_mime` gem.

https://github.com/zendesk/zendesk_api_client_rb/pull/443