### PR TITLE
Include discourse_zendesk_plugin_zendesk_id in post serializer

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -25,6 +25,10 @@ after_initialize do
   require_dependency File.expand_path('../app/jobs/onceoff/migrate_zendesk_enabled_categories_site_settings.rb', __FILE__)
   require_dependency File.expand_path('../app/jobs/regular/zendesk_job.rb', __FILE__)
 
+  add_to_serializer(:post, ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD.to_sym, false) do
+    object.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
+  end
+
   add_to_serializer(:topic_view, ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD.to_sym, false) do
     object.topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
   end


### PR DESCRIPTION
Make the discourse_zendesk_plugin_zendesk_id for the zendesk comment_id available via the API.