### PR TITLE
Use comment_id as when specified in the webhook payload

### DIFF
--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -24,9 +24,9 @@ module DiscourseZendeskPlugin
 
       user = User.find_by_email(params[:email]) || Discourse.system_user
       if params[:comment_id].present?
-          comment = get_public_comment(ticket_id, params[:comment_id].to_i)
-        else
-          comment = get_latest_comment(ticket_id)
+        comment = get_public_comment(ticket_id, params[:comment_id].to_i)
+      else
+        comment = get_latest_comment(ticket_id)
       end
 
       if comment.present?

--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -23,16 +23,21 @@ module DiscourseZendeskPlugin
       return if !DiscourseZendeskPlugin::Helper.category_enabled?(topic.category_id)
 
       user = User.find_by_email(params[:email]) || Discourse.system_user
-      latest_comment = get_latest_comment(ticket_id)
-      if latest_comment.present?
-        existing_comment = PostCustomField.where(name: ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD, value: latest_comment.id).first
+      if params[:comment_id].present?
+          comment = get_public_comment(ticket_id, params[:comment_id].to_i)
+        else
+          comment = get_latest_comment(ticket_id)
+      end
+
+      if comment.present?
+        existing_comment = PostCustomField.where(name: ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD, value: comment.id).first
 
         unless existing_comment.present?
           post = topic.posts.create!(
             user: user,
-            raw: latest_comment.body
+            raw: comment.body
           )
-          update_post_custom_fields(post, latest_comment)
+          update_post_custom_fields(post, comment)
         end
       end
 

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -81,6 +81,16 @@ module DiscourseZendeskPlugin
       last_public_comment
     end
 
+    def get_public_comment(ticket_id, comment_id)
+      return unless comment_id.present?
+
+      # TODO: Pending support ticket with zendesk, can we just load the comment directly?
+      ticket = ZendeskAPI::Ticket.new(zendesk_client, id: ticket_id)
+      ticket.comments.all!.find do |comment|
+        comment.public && (comment.id == comment_id) # expects an integer
+      end
+    end
+
     def update_topic_custom_fields(topic, ticket)
       topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD] = ticket['id']
       topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_API_URL_FIELD] = ticket['url']

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -86,9 +86,11 @@ module DiscourseZendeskPlugin
 
       # TODO: Pending support ticket with zendesk, can we just load the comment directly?
       ticket = ZendeskAPI::Ticket.new(zendesk_client, id: ticket_id)
-      ticket.comments.all!.find do |comment|
-        comment.public && (comment.id == comment_id) # expects an integer
+      ticket.comments.all! do |comment|
+        # Bail as soon as we find our comment_id
+        return comment if comment.public && (comment.id == comment_id) # expects an integer
       end
+      nil # don't return the enumeration
     end
 
     def update_topic_custom_fields(topic, ticket)

--- a/spec/requests/sync_controller_spec.rb
+++ b/spec/requests/sync_controller_spec.rb
@@ -49,5 +49,168 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
       put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: 12 }
       expect(response.status).to eq(204)
     end
+
+    context 'comments' do
+      let(:ticket_id) { 12 }
+      let(:comment_id) { 123 }
+      let(:other_comment_id) { 567 }
+      let(:private_comment_id) { 345 }
+      let(:ticket_comments) { [] }
+      let(:private_comment) do
+        {
+          "author_id": 123123,
+          "body": "Thanks for your help! no attachments",
+          "id": private_comment_id,
+          "public": false,
+          "type": "Comment"
+        }
+      end
+      let(:comment_without_attachment) do
+        {
+          "author_id": 123123,
+          "body": "Thanks for your help! no attachments",
+          "id": other_comment_id,
+          "public": true,
+          "type": "Comment"
+        }
+      end
+      let(:comment_with_attachment) do
+        {
+          "attachments": [
+            {
+              "content_type": "text/plain",
+              "content_url": "https://company.zendesk.com/attachments/crash.log",
+              "file_name": "crash.log",
+              "id": 498483,
+              "size": 2532,
+              "thumbnails": []
+            }
+          ],
+          "author_id": 123123,
+          "body": "Thanks for your help!",
+          "id": comment_id,
+          "public": true,
+          "type": "Comment"
+        }
+      end
+      let(:comments_response_json) do
+        {
+          comments: ticket_comments
+        }.to_json
+      end
+      before(:each) do
+        DiscourseZendeskPlugin::Helper
+          .expects(:category_enabled?)
+          .with(topic.category_id)
+          .returns(category_enabled)
+          .at_least(0)
+
+        stub_request(:get,
+                     "https://your-url.zendesk.com/api/v2/tickets/#{ticket_id}/comments"
+        ).to_return(status: 200,
+                    body: comments_response_json,
+                    headers: {
+                      content_type: "application/json",
+                    })
+      end
+
+      context 'without comment_id' do
+        context 'category disabled' do
+          let(:category_enabled) { false }
+          it 'returns 204 when the request succeeds' do
+            put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+            expect(response.status).to eq(204)
+          end
+        end
+        context 'category enabled' do
+          let(:category_enabled) { true }
+          context 'no comments' do
+            it 'returns 204 when the request succeeds' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(response.status).to eq(204)
+            end
+            it "doesn't add a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              end.to_not change { topic.reload.posts.count }
+            end
+          end
+
+          context 'with comments' do
+            let(:ticket_comments) do
+              [
+                comment_with_attachment,
+                comment_without_attachment,
+                private_comment
+              ]
+            end
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(response.status).to eq(204)
+            end
+            it "Adds a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              end.to change { topic.reload.posts.count }.from(0).to(1)
+            end
+            it "Adds correct comment post" do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(
+                topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
+              ).to eq other_comment_id.to_s
+            end
+          end
+        end
+      end
+
+      context 'with comment_id' do
+        context 'category disabled' do
+          let(:category_enabled) { false }
+          it 'returns 204 when the request succeeds with comment_id' do
+            put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+            expect(response.status).to eq(204)
+          end
+        end
+        context 'category enabled' do
+          let(:category_enabled) { true }
+          context 'no comments' do
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(response.status).to eq(204)
+            end
+            it "doesn't add a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              end.to_not change { topic.reload.posts.count }
+            end
+          end
+
+          context 'with comments' do
+            let(:ticket_comments) do
+              [
+                private_comment,
+                comment_with_attachment,
+                comment_without_attachment
+              ]
+            end
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(response.status).to eq(204)
+            end
+            it "Adds a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              end.to change { topic.reload.posts.count }.from(0).to(1)
+            end
+            it "Adds correct comment post" do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(
+                topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
+              ).to eq comment_id.to_s
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/requests/sync_controller_spec.rb
+++ b/spec/requests/sync_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
                 put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
               end.to change { topic.reload.posts.count }.from(0).to(1)
             end
-            it "Adds correct comment post" do
+            it "Adds correct comment post (ignores private post and older comment)" do
               put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
               expect(
                 topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
@@ -202,7 +202,7 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
                 put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
               end.to change { topic.reload.posts.count }.from(0).to(1)
             end
-            it "Adds correct comment post" do
+            it "Adds correct comment post (ignores private post and more recent comment)" do
               put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
               expect(
                 topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]


### PR DESCRIPTION
We had a bug which I think is caused by the use of the lastest_comment in the webhook.
This change is intended to allow the webhook to specify a comment_id and to use that 

The idea is that this is the trigger payload:

```
{   
  "ticket_id" : "{{ticket.id}}", 
  "topic_id": "{{ticket.external_id}}",
  "comment_id": "{{ticket.latest_comment.id}}",
  "email": "{{ticket.latest_comment.author.email}}",
 }
```