### PR TITLE
Include attachments from Zendesk Comment and use body_html

### DIFF
--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -24,9 +24,9 @@ module DiscourseZendeskPlugin
 
       user = User.find_by_email(params[:email]) || Discourse.system_user
       if params[:comment_id].present?
-          comment = get_public_comment(ticket_id, params[:comment_id].to_i)
-        else
-          comment = get_latest_comment(ticket_id)
+        comment = get_public_comment(ticket_id, params[:comment_id].to_i)
+      else
+        comment = get_latest_comment(ticket_id)
       end
 
       if comment.present?

--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -46,21 +46,6 @@ module DiscourseZendeskPlugin
 
     private
 
-    def build_raw_post_body(comment)
-      return comment.body unless SiteSetting.zendesk_append_attachments?
-
-      comment.body + build_raw_attachments_string(comment)
-    end
-
-    def build_raw_attachments_string(comment)
-      return '' if comment.attachments.blank?
-
-      "\n\n**Attachments**\n\n" + comment.attachments.map do |attachment|
-        "* [#{attachment.file_name} (#{attachment.content_type})](#{attachment.content_url})"
-      end.join("\n")
-    end
-
-
     def zendesk_token_valid?
       params.require(:token)
 

--- a/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -23,16 +23,21 @@ module DiscourseZendeskPlugin
       return if !DiscourseZendeskPlugin::Helper.category_enabled?(topic.category_id)
 
       user = User.find_by_email(params[:email]) || Discourse.system_user
-      latest_comment = get_latest_comment(ticket_id)
-      if latest_comment.present?
-        existing_comment = PostCustomField.where(name: ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD, value: latest_comment.id).first
+      if params[:comment_id].present?
+          comment = get_public_comment(ticket_id, params[:comment_id].to_i)
+        else
+          comment = get_latest_comment(ticket_id)
+      end
+
+      if comment.present?
+        existing_comment = PostCustomField.where(name: ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD, value: comment.id).first
 
         unless existing_comment.present?
           post = topic.posts.create!(
             user: user,
-            raw: latest_comment.body
+            raw: comment.body
           )
-          update_post_custom_fields(post, latest_comment)
+          update_post_custom_fields(post, comment)
         end
       end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,6 +9,7 @@ en:
       general_error: Something went wrong.
   site_settings:
     zendesk_url: Your Zendesk URL. e.g. https://YOUR_SUBDOMAIN.zendesk.com/api/v2
+    zendesk_append_attachments: Append Zendesk comment attachments to posts. Applies only if `sync_comments_from_zendesk` is enabled.
     zendesk_enabled: Enable Zendesk plugin
     zendesk_enable_all_categories: Create tickets for all categories. If enabled, `zendesk_enabled_categories` are ignored.
     zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets.

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,7 +9,7 @@ en:
       general_error: Something went wrong.
   site_settings:
     zendesk_url: Your Zendesk URL. e.g. https://YOUR_SUBDOMAIN.zendesk.com/api/v2
-    zendesk_append_attachments: Append Zendesk comment attachments to posts. Applies only if `sync_comments_from_zendesk` is enabled.
+    zendesk_append_attachments: Use the HTML Zendesk Comment Body and append the attachments to posts. Applies only if `sync_comments_from_zendesk` is enabled.
     zendesk_enabled: Enable Zendesk plugin
     zendesk_enable_all_categories: Create tickets for all categories. If enabled, `zendesk_enabled_categories` are ignored.
     zendesk_enabled_categories: List of categories that will autogenerate Zendesk tickets.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,8 @@ plugins:
     default: false
   zendesk_incoming_webhook_token:
     default: ''
+  zendesk_append_attachments:
+    default: false
   zendesk_tags:
     type: list
     client: false

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -81,6 +81,16 @@ module DiscourseZendeskPlugin
       last_public_comment
     end
 
+    def get_public_comment(ticket_id, comment_id)
+      return unless comment_id.present?
+
+      # TODO: Pending support ticket with zendesk, can we just load the comment directly?
+      ticket = ZendeskAPI::Ticket.new(zendesk_client, id: ticket_id)
+      ticket.comments.all!.find do |comment|
+        comment.public && (comment.id == comment_id) # expects an integer
+      end
+    end
+
     def update_topic_custom_fields(topic, ticket)
       topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD] = ticket['id']
       topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_API_URL_FIELD] = ticket['url']

--- a/lib/discourse_zendesk_plugin/helper.rb
+++ b/lib/discourse_zendesk_plugin/helper.rb
@@ -86,9 +86,11 @@ module DiscourseZendeskPlugin
 
       # TODO: Pending support ticket with zendesk, can we just load the comment directly?
       ticket = ZendeskAPI::Ticket.new(zendesk_client, id: ticket_id)
-      ticket.comments.all!.find do |comment|
-        comment.public && (comment.id == comment_id) # expects an integer
+      ticket.comments.all! do |comment|
+        # Bail as soon as we find our comment_id
+        return comment if comment.public && (comment.id == comment_id) # expects an integer
       end
+      nil # don't return the enumeration
     end
 
     def update_topic_custom_fields(topic, ticket)

--- a/spec/lib/discourse_zendesk_plugin/helper_spec.rb
+++ b/spec/lib/discourse_zendesk_plugin/helper_spec.rb
@@ -59,4 +59,93 @@ describe DiscourseZendeskPlugin::Helper do
       end
     end
   end
+
+  describe 'build_raw_post_body' do
+    before do
+      SiteSetting.zendesk_append_attachments = zendesk_append_attachments
+      comment.stubs(:body).returns(comment_body)
+      comment.stubs(:html_body).returns(comment_html_body)
+      comment.stubs(:attachments).returns(comment_attachments)
+    end
+    let(:comment) { mock('ZendeskAPI::Trackie') }
+    let(:comment_body) { 'This is a test' }
+    let(:comment_html_body) { '<p>This is a <a href="http://example.com/">test</a></p>' }
+    let(:comment_attachments) { [] }
+    subject(:body) { dummy.build_raw_post_body(comment) }
+    context 'zendesk_append_attachments disabled' do
+      let(:zendesk_append_attachments) { false }
+      it 'uses comment body' do
+        expect(body).to eq comment.body
+      end
+    end
+    context 'zendesk_append_attachments enabled' do
+      let(:zendesk_append_attachments) { true }
+      it 'uses comment body' do
+        expect(body).to eq comment.html_body
+      end
+      context 'has text attachment' do
+        let(:text_file_attachment) do
+          ZendeskAPI::Trackie.new(
+            "content_type": "text/plain",
+            "content_url": "https://company.zendesk.com/attachments/crash.log",
+            "file_name": "crash.log",
+            "id": 498483,
+            "size": 2532,
+          )
+        end
+        let(:comment_attachments) do
+          [
+            text_file_attachment
+          ]
+        end
+        it 'appends attachments to comment html body' do
+          expect(body).to start_with comment.html_body
+          expect(body).to include "[crash.log (text/plain)](https://company.zendesk.com/attachments/crash.log)"
+        end
+        context 'and image thumbnail attachment' do
+          let(:thumbnailed_attachment) do
+            ZendeskAPI::Trackie.new(
+              "content_type": "image/jpeg",
+              "content_url": "https://example.zendesk.com/attachments/token/XXXX/,?name=happyday.jpeg",
+              "deleted": false,
+              "file_name": "happyday.jpeg",
+              "height": 189,
+              "id": 1261712928789,
+              "inline": false,
+              "mapped_content_url": "https://support.example.com/attachments/token/XXXX/?name=happyday.jpeg",
+              "size": 5223,
+              "url": "https://example.zendesk.com/api/v2/attachments/1234.json",
+              "width": 267,
+              "thumbnails": [
+                {
+                  "content_type": "image/jpeg",
+                  "content_url": "https://example.zendesk.com/attachments/token/XXXX/,?name=happyday_thumb.jpeg",
+                  "deleted": false,
+                  "file_name": "happyday_thumb.jpeg",
+                  "height": 57,
+                  "id": 1261712928829,
+                  "inline": false,
+                  "mapped_content_url": "https://support.example.com/attachments/token/XXXX/,?name=happyday_thumb.jpeg",
+                  "size": 1497,
+                  "url": "https://example.zendesk.com/api/v2/attachments/1235.json",
+                  "width": 80
+                }
+              ]
+            )
+          end
+          let(:comment_attachments) do
+            [
+              text_file_attachment,
+              thumbnailed_attachment
+            ]
+          end
+          it 'appends attachments to comment html body' do
+            expect(body).to start_with comment.html_body
+            expect(body).to include "[crash.log (text/plain)](https://company.zendesk.com/attachments/crash.log)"
+            expect(body).to include "[![](https://support.example.com/attachments/token/XXXX/,?name=happyday_thumb.jpeg)](https://support.example.com/attachments/token/XXXX/?name=happyday.jpeg)"
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/sync_controller_spec.rb
+++ b/spec/requests/sync_controller_spec.rb
@@ -49,5 +49,168 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
       put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: 12 }
       expect(response.status).to eq(204)
     end
+
+    context 'comments' do
+      let(:ticket_id) { 12 }
+      let(:comment_id) { 123 }
+      let(:other_comment_id) { 567 }
+      let(:private_comment_id) { 345 }
+      let(:ticket_comments) { [] }
+      let(:private_comment) do
+        {
+          "author_id": 123123,
+          "body": "Thanks for your help! no attachments",
+          "id": private_comment_id,
+          "public": false,
+          "type": "Comment"
+        }
+      end
+      let(:comment_without_attachment) do
+        {
+          "author_id": 123123,
+          "body": "Thanks for your help! no attachments",
+          "id": other_comment_id,
+          "public": true,
+          "type": "Comment"
+        }
+      end
+      let(:comment_with_attachment) do
+        {
+          "attachments": [
+            {
+              "content_type": "text/plain",
+              "content_url": "https://company.zendesk.com/attachments/crash.log",
+              "file_name": "crash.log",
+              "id": 498483,
+              "size": 2532,
+              "thumbnails": []
+            }
+          ],
+          "author_id": 123123,
+          "body": "Thanks for your help!",
+          "id": comment_id,
+          "public": true,
+          "type": "Comment"
+        }
+      end
+      let(:comments_response_json) do
+        {
+          comments: ticket_comments
+        }.to_json
+      end
+      before(:each) do
+        DiscourseZendeskPlugin::Helper
+          .expects(:category_enabled?)
+          .with(topic.category_id)
+          .returns(category_enabled)
+          .at_least(0)
+
+        stub_request(:get,
+                     "https://your-url.zendesk.com/api/v2/tickets/#{ticket_id}/comments"
+        ).to_return(status: 200,
+                    body: comments_response_json,
+                    headers: {
+                      content_type: "application/json",
+                    })
+      end
+
+      context 'without comment_id' do
+        context 'category disabled' do
+          let(:category_enabled) { false }
+          it 'returns 204 when the request succeeds' do
+            put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+            expect(response.status).to eq(204)
+          end
+        end
+        context 'category enabled' do
+          let(:category_enabled) { true }
+          context 'no comments' do
+            it 'returns 204 when the request succeeds' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(response.status).to eq(204)
+            end
+            it "doesn't add a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              end.to_not change { topic.reload.posts.count }
+            end
+          end
+
+          context 'with comments' do
+            let(:ticket_comments) do
+              [
+                comment_with_attachment,
+                comment_without_attachment,
+                private_comment
+              ]
+            end
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(response.status).to eq(204)
+            end
+            it "Adds a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              end.to change { topic.reload.posts.count }.from(0).to(1)
+            end
+            it "Adds correct comment post" do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
+              expect(
+                topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
+              ).to eq other_comment_id.to_s
+            end
+          end
+        end
+      end
+
+      context 'with comment_id' do
+        context 'category disabled' do
+          let(:category_enabled) { false }
+          it 'returns 204 when the request succeeds with comment_id' do
+            put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+            expect(response.status).to eq(204)
+          end
+        end
+        context 'category enabled' do
+          let(:category_enabled) { true }
+          context 'no comments' do
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(response.status).to eq(204)
+            end
+            it "doesn't add a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              end.to_not change { topic.reload.posts.count }
+            end
+          end
+
+          context 'with comments' do
+            let(:ticket_comments) do
+              [
+                private_comment,
+                comment_with_attachment,
+                comment_without_attachment
+              ]
+            end
+            it 'returns 204 when the request succeeds with comment_id' do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(response.status).to eq(204)
+            end
+            it "Adds a post" do
+              expect do
+                put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              end.to change { topic.reload.posts.count }.from(0).to(1)
+            end
+            it "Adds correct comment post" do
+              put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
+              expect(
+                topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
+              ).to eq comment_id.to_s
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/requests/sync_controller_spec.rb
+++ b/spec/requests/sync_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
                 put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
               end.to change { topic.reload.posts.count }.from(0).to(1)
             end
-            it "Adds correct comment post" do
+            it "Adds correct comment post (ignores private post and older comment)" do
               put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id }
               expect(
                 topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
@@ -202,7 +202,7 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
                 put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
               end.to change { topic.reload.posts.count }.from(0).to(1)
             end
-            it "Adds correct comment post" do
+            it "Adds correct comment post (ignores private post and more recent comment)" do
               put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: ticket_id, comment_id: comment_id }
               expect(
                 topic.reload.posts.last.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]


### PR DESCRIPTION
Codebase builds on previous commit_id PR but isn't really dependent on it

To get inline links and attachments from zendesk comment

Adds new zendesk_append_attachments setting (default false) which maintains current behaviour