### PR TITLE
FIX: creating ticket spec was generating errors

### DIFF
--- a/spec/integration/zendesk_plugin_spec.rb
+++ b/spec/integration/zendesk_plugin_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'Discourse Zendesk Plugin' do
       before do
         sign_in staff
         default_header = { 'Content-Type' => 'application/json; charset=UTF-8' }
+        stub_request(:get, zendesk_api_ticket_url + "/ticket_id/comments").to_return(status: 200)
         stub_request(:get, zendesk_api_user_search_url).
           to_return(status: 200, body: { user: {} }.to_json, headers: default_header)
         stub_request(:post, zendesk_api_user_create_url).
@@ -71,8 +72,10 @@ RSpec.describe 'Discourse Zendesk Plugin' do
           }
         }
 
-        expect(topic.custom_fields['discourse_zendesk_plugin_zendesk_api_url']).to eq('ticket_url')
-        expect(topic.custom_fields['discourse_zendesk_plugin_zendesk_id']).to eq('ticket_id')
+        custom_fields = topic.reload.custom_fields
+
+        expect(custom_fields['discourse_zendesk_plugin_zendesk_api_url']).to eq('ticket_url')
+        expect(custom_fields['discourse_zendesk_plugin_zendesk_id']).to eq('ticket_id')
       end
     end
   end


### PR DESCRIPTION
- one request was not mocked
- custom fields could not be correctly loaded at the point we were checking them