### PR TITLE
DEV: Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     prettier_print (1.2.0)
     rainbow (3.1.1)
     regexp_parser (2.6.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)


### PR DESCRIPTION
Core just updated rexml to 3.2.6 so we will need to update the one here as well. https://github.com/discourse/discourse/pull/22843

```
gem dependency rexml --reverse-dependencies
Gem rexml-3.2.5
  bundler (>= 0, development)
  rake (>= 0, development)
  test-unit (>= 0, development)
  Used by
    crack-0.4.5 (rexml (>= 0))
    oauth2-2.0.9 (rexml (>= 3, development))
    oauth2-1.4.11 (rexml (>= 3, development))
    rss-0.2.9 (rexml (>= 0))
    rubocop-1.55.1 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.55.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.54.2 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.54.1 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.53.1 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.53.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.52.1 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.52.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.51.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.50.2 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.43.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.36.0 (rexml (>= 3.2.5, < 4.0))
    rubocop-1.28.0 (rexml (>= 0))
    rubocop-1.23.0 (rexml (>= 0))
    ruby-debug-ide-3.0.0.beta.2 (rexml (~> 3.2.4, development))
    selenium-webdriver-4.10.0 (rexml (~> 3.2, >= 3.2.5))
    selenium-webdriver-4.9.1 (rexml (~> 3.2, >= 3.2.5))
    selenium-webdriver-4.9.0 (rexml (~> 3.2, >= 3.2.5))
    selenium-webdriver-4.8.6 (rexml (~> 3.2, >= 3.2.5))
    selenium-webdriver-4.7.1 (rexml (~> 3.2, >= 3.2.5))
```