### PR TITLE
DEV: Pass respect_plugin_enabled to add_to_serializer as keyword argument

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -37,11 +37,17 @@ after_initialize do
     Topic.prepend DiscourseZendeskPlugin::TopicExtension
   end
 
-  add_to_serializer(:topic_view, ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD.to_sym, false) do
-    object.topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
-  end
+  add_to_serializer(
+    :topic_view,
+    ::DiscourseZendeskPlugin::ZENDESK_ID_FIELD.to_sym,
+    respect_plugin_enabled: false,
+  ) { object.topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD] }
 
-  add_to_serializer(:topic_view, ::DiscourseZendeskPlugin::ZENDESK_URL_FIELD.to_sym, false) do
+  add_to_serializer(
+    :topic_view,
+    ::DiscourseZendeskPlugin::ZENDESK_URL_FIELD.to_sym,
+    respect_plugin_enabled: false,
+  ) do
     id = object.topic.custom_fields[::DiscourseZendeskPlugin::ZENDESK_ID_FIELD]
     uri = URI.parse(SiteSetting.zendesk_url)
     "#{uri.scheme}://#{uri.host}/agent/tickets/#{id}"


### PR DESCRIPTION
### What is this change?

Passing the `respect_plugin_enabled` argument to `#add_to_serializer` as a positional argument is deprecated. It is now expected to be a keyword argument. This PR adds the keyword.