### PR TITLE
DEV: Change settings root from plugins: to discourse_zendesk

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_zendesk: "Discourse Zendesk"
   js:
     topic:
       create_zendesk_issue: "Create Zendesk Ticket"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_zendesk:
   zendesk_url:
     default: https://your-url.zendesk.com/api/v2
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.